### PR TITLE
Fix kops state bucket bug

### DIFF
--- a/modules/aws/state_bucket/state_bucket.tf
+++ b/modules/aws/state_bucket/state_bucket.tf
@@ -7,7 +7,7 @@ variable "account"        { }
 variable "tool"           { default = "terraform" }
 variable "project"        { }
 variable "stack"          { }
-variable "prod_acount_id" { }
+variable "prod_account_id" { }
 
 resource "aws_s3_bucket" "state_bucket" {
   bucket = "${var.project}-${var.tool}-${var.stack}"
@@ -21,7 +21,7 @@ resource "aws_s3_bucket" "state_bucket" {
       "Sid":"Allow Prod Access to ${var.project}-${var.tool}-${var.stack}",
       "Effect":"Allow",
       "Principal": {
-          "AWS": "arn:aws:iam::${var.prod_acount_id}:root"
+          "AWS": "arn:aws:iam::${var.prod_account_id}:root"
       },
       "Action": "s3:ListBucket",
       "Resource": "arn:aws:s3:::${var.project}-${var.tool}-${var.stack}"
@@ -30,7 +30,7 @@ resource "aws_s3_bucket" "state_bucket" {
       "Sid":"Allow Prod Access to ${var.project}-${var.tool}-${var.stack}/*",
       "Effect":"Allow",
       "Principal": {
-          "AWS": "arn:aws:iam::${var.prod_acount_id}:root"
+          "AWS": "arn:aws:iam::${var.prod_account_id}:root"
       },
       "Action": "s3:*",
       "Resource": "arn:aws:s3:::${var.project}-${var.tool}-${var.stack}/*"

--- a/modules/aws/state_bucket/state_bucket.tf
+++ b/modules/aws/state_bucket/state_bucket.tf
@@ -11,7 +11,7 @@ variable "prod_acount_id" { }
 
 resource "aws_s3_bucket" "state_bucket" {
   bucket = "${var.project}-${var.tool}-${var.stack}"
-  count  = "${var.account == var.prod_acount_id ? 0 : 1}"
+  count  = "${var.account == "prod" ? 0 : 1}"
   acl    = "private"
   policy = <<EOF
 {

--- a/providers/aws/global/global.tf
+++ b/providers/aws/global/global.tf
@@ -96,7 +96,7 @@ module "global_state_bucket" {
   source         = "../../../modules/aws/state_bucket"
   project        = "${var.project}"
   stack          = "global"
-  prod_acount_id = "${var.prod_account_id}"
+  prod_account_id = "${var.prod_account_id}"
 }
 
 module "mgmt_state_bucket" {
@@ -104,7 +104,7 @@ module "mgmt_state_bucket" {
   source         = "../../../modules/aws/state_bucket"
   project        = "${var.project}"
   stack          = "mgmt"
-  prod_acount_id = "${var.prod_account_id}"
+  prod_account_id = "${var.prod_account_id}"
 }
 
 module "service_state_bucket" {
@@ -112,7 +112,7 @@ module "service_state_bucket" {
   source         = "../../../modules/aws/state_bucket"
   project        = "${var.project}"
   stack          = "service"
-  prod_acount_id = "${var.prod_account_id}"
+  prod_account_id = "${var.prod_account_id}"
 }
 
 module "vpcpeering_state_bucket" {
@@ -120,7 +120,7 @@ module "vpcpeering_state_bucket" {
   source         = "../../../modules/aws/state_bucket"
   project        = "${var.project}"
   stack          = "vpcpeering"
-  prod_acount_id = "${var.prod_account_id}"
+  prod_account_id = "${var.prod_account_id}"
 }
 
 module "kops_state_bucket" {
@@ -129,7 +129,7 @@ module "kops_state_bucket" {
   project        = "${var.project}"
   tool           = "${var.account}"
   stack          = "kops"
-  prod_acount_id = "0"
+  prod_account_id = "0"
 }
 
 output "prod_account_id" { value = "${var.prod_account_id}" }


### PR DESCRIPTION
This checks if var.account == var.prod_account_id, but var.account is a
string and var.prod_account_id is a number, so these can never match

Also fix typo in prod_account_id - the var we pass in correctly has 2 'c's, so the var in terraform also needs to