### PR TITLE
Fix kops bucket to correct name

### DIFF
--- a/providers/aws/global/global.tf
+++ b/providers/aws/global/global.tf
@@ -124,7 +124,7 @@ module "vpcpeering_state_bucket" {
 }
 
 resource "aws_s3_bucket" "kops_state_bucket" {
-  bucket = "${var.project}-${var.account}-kops-state"
+  bucket = "${var.project}-${var.account}-kops"
   acl    = "private"
 
   versioning {
@@ -151,7 +151,7 @@ resource "aws_s3_bucket" "kops_state_bucket" {
   }
 
   tags {
-    Name    = "${var.project}-${var.account}-kops-state"
+    Name    = "${var.project}-${var.account}-kops"
     Project = "${var.project}"
   }
 }


### PR DESCRIPTION
microdc-init expects this bucket to not end in '-state'